### PR TITLE
Use template metaprogramming to validate autodiff methods at compile time

### DIFF
--- a/autodiff/autodiff.hpp
+++ b/autodiff/autodiff.hpp
@@ -2,6 +2,7 @@
 #define nomad__autodiff__autodiff_hpp
 
 #include <autodiff/autodiff_stack.hpp>
+#include <autodiff/base_functor.hpp>
 #include <autodiff/first_order.hpp>
 #include <autodiff/second_order.hpp>
 #include <autodiff/third_order.hpp>

--- a/autodiff/base_functor.hpp
+++ b/autodiff/base_functor.hpp
@@ -1,0 +1,17 @@
+#ifndef nomad__autodiff__base_functor_hpp
+#define nomad__autodiff__base_functor_hpp
+
+#include <Eigen/Core>
+
+namespace nomad {
+  
+  template<class T>
+  class base_functor {
+  public:
+    virtual T operator()(const Eigen::VectorXd& x) const;
+    typedef T var_type;
+  };
+  
+}
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -7,8 +7,8 @@
 #include <matrix/functions.hpp>
 
 #include <tests/validate_exceptions.hpp>
-#include <tests/test_scalar_functions.hpp>
-#include <tests/test_scalar_operators.hpp>
+//#include <tests/test_scalar_functions.hpp>
+//#include <tests/test_scalar_operators.hpp>
 
 using namespace nomad;
 
@@ -21,7 +21,8 @@ void validate_dot();
 void time_dot();
 
 template <typename T, int N>
-struct funnel_func {
+class funnel_func: public base_functor<T> {
+public:
   T operator()(const Eigen::VectorXd& x) const {
     
     T v = x[0];
@@ -45,10 +46,11 @@ struct funnel_func {
 };
 
 template <typename T>
-struct f_matrix {
+class f_matrix: public base_functor<T> {
+public:
   T operator()(const Eigen::VectorXd& x) const {
     
-    eigen_idx_t N = static_cast<eigen_idx_t>(sqrt(x.size()));
+    eigen_idx_t N = static_cast<eigen_idx_t>(std::sqrt(x.size()));
     
     Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> M(N, N);
     
@@ -63,7 +65,8 @@ struct f_matrix {
 };
 
 template <typename T>
-struct f_dot {
+class f_dot: public base_functor<T> {
+public:
   T operator()(const Eigen::VectorXd& x) const {
     
     eigen_idx_t N = x.size() / 2;
@@ -328,11 +331,10 @@ void time_dot() {
   
 }
 
-
 int main(int argc, const char * argv[]) {
   //validate_exceptions();
   
-  //validate_funnel();
+  validate_funnel();
   //time_funnel();
   
   //validate_matrix();
@@ -341,8 +343,8 @@ int main(int argc, const char * argv[]) {
   //validate_dot();
   //time_dot();
   
-  test_scalar_functions();
-  test_scalar_operators();
+  //test_scalar_functions();
+  //test_scalar_operators();
   
   return 0;
 }

--- a/tests/test_scalar_functions.hpp
+++ b/tests/test_scalar_functions.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include <autodiff/base_functor.hpp>
 #include <scalar/functions.hpp>
 #include <tests/finite_difference.hpp>
 
@@ -89,7 +90,8 @@ namespace nomad {
   
   // acos
   template <typename T>
-  struct acos_func {
+  class acos_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return acos(v);
@@ -106,7 +108,8 @@ namespace nomad {
   
   // acosh
   template <typename T>
-  struct acosh_func {
+  class acosh_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return acosh(v);
@@ -123,7 +126,8 @@ namespace nomad {
   
   // asin
   template <typename T>
-  struct asin_func {
+  class asin_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return asin(v);
@@ -140,7 +144,8 @@ namespace nomad {
   
   // asinh
   template <typename T>
-  struct asinh_func {
+  class asinh_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return asinh(v);
@@ -157,7 +162,8 @@ namespace nomad {
   
   // atan
   template <typename T>
-  struct atan_func {
+  class atan_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return atan(v);
@@ -174,7 +180,8 @@ namespace nomad {
   
   // atan2
   template <typename T>
-  struct atan2_vv_func {
+  class atan2_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -185,7 +192,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct atan2_vd_func {
+  class atan2_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return atan2(v, 0.4847);
@@ -195,7 +203,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct atan2_dv_func {
+  class atan2_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return atan2(0.3898, v);
@@ -220,7 +229,8 @@ namespace nomad {
   
   // atanh
   template <typename T>
-  struct atanh_func {
+  class atanh_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return atanh(v);
@@ -237,7 +247,8 @@ namespace nomad {
  
   // binary_prod_cubes
   template <typename T>
-  struct binary_prod_cubes_func {
+  class binary_prod_cubes_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -256,7 +267,8 @@ namespace nomad {
 
   // cbrt
   template <typename T>
-  struct cbrt_func {
+  class cbrt_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return cbrt(v);
@@ -273,7 +285,8 @@ namespace nomad {
   
   // cos
   template <typename T>
-  struct cos_func {
+  class cos_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return cos(v);
@@ -290,7 +303,8 @@ namespace nomad {
   
   // cosh
   template <typename T>
-  struct cosh_func {
+  class cosh_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return cosh(v);
@@ -307,7 +321,8 @@ namespace nomad {
 
   // erf
   template <typename T>
-  struct erf_func {
+  class erf_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return erf(v);
@@ -324,7 +339,8 @@ namespace nomad {
   
   // erfc
   template <typename T>
-  struct erfc_func {
+  class erfc_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return erfc(v);
@@ -341,7 +357,8 @@ namespace nomad {
   
   // exp
   template <typename T>
-  struct exp_func {
+  class exp_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v);
@@ -358,7 +375,8 @@ namespace nomad {
   
   // exp2
   template <typename T>
-  struct exp2_func {
+  class exp2_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp2(v);
@@ -375,7 +393,8 @@ namespace nomad {
   
   // expm1
   template <typename T>
-  struct expm1_func {
+  class expm1_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return expm1(v);
@@ -392,7 +411,8 @@ namespace nomad {
   
   // fma
   template <typename T>
-  struct fma_func {
+  class fma_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -413,7 +433,8 @@ namespace nomad {
   
   // hypot
   template <typename T>
-  struct hypot_vv_func {
+  class hypot_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -424,7 +445,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct hypot_vd_func {
+  class hypot_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return hypot(v, 0.4847);
@@ -434,7 +456,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct hypot_dv_func {
+  class hypot_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return hypot(0.3898, v);
@@ -459,7 +482,8 @@ namespace nomad {
 
   // inv_cloglog
   template <typename T>
-  struct inv_cloglog_func {
+  class inv_cloglog_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return inv_cloglog(v);
@@ -476,7 +500,8 @@ namespace nomad {
   
   // inv_logit
   template <typename T>
-  struct inv_logit_func {
+  class inv_logit_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return inv_logit(v);
@@ -493,7 +518,8 @@ namespace nomad {
   
   // inv_sqrt
   template <typename T>
-  struct inv_sqrt_func {
+  class inv_sqrt_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return inv_sqrt(v);
@@ -510,7 +536,8 @@ namespace nomad {
   
   // inv_square
   template <typename T>
-  struct inv_square_func {
+  class inv_square_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return inv_square(v);
@@ -527,7 +554,8 @@ namespace nomad {
   
   // inv
   template <typename T>
-  struct inv_func {
+  class inv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return inv(v);
@@ -544,7 +572,8 @@ namespace nomad {
   
   // log_diff_exp
   template <typename T>
-  struct log_diff_exp_vv_func {
+  class log_diff_exp_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -555,7 +584,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct log_diff_exp_vd_func {
+  class log_diff_exp_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log_diff_exp(v, 0.5);
@@ -565,7 +595,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct log_diff_exp_dv_func {
+  class log_diff_exp_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log_diff_exp(0.5, v);
@@ -597,7 +628,8 @@ namespace nomad {
   
   // log_sum_exp
   template <typename T>
-  struct log_sum_exp_vv_func {
+  class log_sum_exp_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -608,7 +640,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct log_sum_exp_vd_func {
+  class log_sum_exp_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log_sum_exp(v, 0.5);
@@ -618,7 +651,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct log_sum_exp_dv_func {
+  class log_sum_exp_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log_sum_exp(0.5, v);
@@ -650,7 +684,8 @@ namespace nomad {
 
   // log
   template <typename T>
-  struct log_func {
+  class log_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log(v);
@@ -667,7 +702,8 @@ namespace nomad {
 
   // log1p_exp
   template <typename T>
-  struct log1p_exp_func {
+  class log1p_exp_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log1p_exp(v);
@@ -686,7 +722,8 @@ namespace nomad {
   
   // log1p
   template <typename T>
-  struct log1p_func {
+  class log1p_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log1p(v);
@@ -703,7 +740,8 @@ namespace nomad {
   
   // log2
   template <typename T>
-  struct log2_func {
+  class log2_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log2(v);
@@ -720,7 +758,8 @@ namespace nomad {
   
   // log10
   template <typename T>
-  struct log10_func {
+  class log10_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return log10(v);
@@ -737,7 +776,8 @@ namespace nomad {
   
   // multiply_log
   template <typename T>
-  struct multiply_log_vv_func {
+  class multiply_log_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -748,7 +788,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct multiply_log_vd_func {
+  class multiply_log_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return multiply_log(v, 0.5);
@@ -758,7 +799,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct multiply_log_dv_func {
+  class multiply_log_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return multiply_log(0.5, v);
@@ -783,7 +825,8 @@ namespace nomad {
   
   // pow
   template <typename T>
-  struct pow_vv_func {
+  class pow_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -794,7 +837,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct pow_vd_func {
+  class pow_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return pow(v, 0.4847);
@@ -804,7 +848,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct pow_dv_func {
+  class pow_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return pow(0.3898, v);
@@ -829,7 +874,8 @@ namespace nomad {
 
   // Phi
   template <typename T>
-  struct Phi_func {
+  class Phi_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return Phi(v);
@@ -846,7 +892,8 @@ namespace nomad {
   
   // sin
   template <typename T>
-  struct sin_func {
+  class sin_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return sin(v);
@@ -863,7 +910,8 @@ namespace nomad {
   
   // sinh
   template <typename T>
-  struct sinh_func {
+  class sinh_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return sinh(v);
@@ -880,7 +928,8 @@ namespace nomad {
   
   // sqrt
   template <typename T>
-  struct sqrt_func {
+  class sqrt_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return sqrt(v);
@@ -897,7 +946,8 @@ namespace nomad {
   
   // square
   template <typename T>
-  struct square_func {
+  class square_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return square(exp(v));
@@ -914,7 +964,8 @@ namespace nomad {
   
   // tan
   template <typename T>
-  struct tan_func {
+  class tan_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return tan(v);
@@ -931,7 +982,8 @@ namespace nomad {
   
   // tanh
   template <typename T>
-  struct tanh_func {
+  class tanh_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return tanh(v);
@@ -948,7 +1000,8 @@ namespace nomad {
   
   // trinary_prod_cubes
   template <typename T>
-  struct trinary_prod_cubes_func {
+  class trinary_prod_cubes_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -966,7 +1019,7 @@ namespace nomad {
     x[1] = -1.765;
     tests::test_function<trinary_prod_cubes_func>(x);
   }
-
+  
 }
 
 #endif

--- a/tests/test_scalar_operators.hpp
+++ b/tests/test_scalar_operators.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include <autodiff/base_functor.hpp>
 #include <scalar/operators.hpp>
 #include <tests/finite_difference.hpp>
 
@@ -39,7 +40,8 @@ namespace nomad {
 
   // operator_addition_assignment
   template <typename T>
-  struct operator_addition_assignment_vv_func {
+  class operator_addition_assignment_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -49,7 +51,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_addition_assignment_vd_func {
+  class operator_addition_assignment_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v + 0.4847);
@@ -73,7 +76,8 @@ namespace nomad {
   
   // operator_addition
   template <typename T>
-  struct operator_addition_vv_func {
+  class operator_addition_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -84,7 +88,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_addition_vd_func {
+  class operator_addition_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v + 0.4847);
@@ -94,7 +99,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_addition_dv_func {
+  class operator_addition_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(0.3898 + v);
@@ -119,7 +125,8 @@ namespace nomad {
 
   // operator_division_assignment
   template <typename T>
-  struct operator_division_assignment_vv_func {
+  class operator_division_assignment_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -129,7 +136,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_division_assignment_vd_func {
+  class operator_division_assignment_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v /= 0.4847);
@@ -153,7 +161,8 @@ namespace nomad {
   
   // operator_division
   template <typename T>
-  struct operator_division_vv_func {
+  class operator_division_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -164,7 +173,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_division_vd_func {
+  class operator_division_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v / 0.4847);
@@ -174,7 +184,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_division_dv_func {
+  class operator_division_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(0.3898 / v);
@@ -199,7 +210,8 @@ namespace nomad {
   
   // operator_multiplication_assignment
   template <typename T>
-  struct operator_multiplication_assignment_vv_func {
+  class operator_multiplication_assignment_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -209,7 +221,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_multiplication_assignment_vd_func {
+  class operator_multiplication_assignment_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v *= 0.4847);
@@ -233,7 +246,8 @@ namespace nomad {
   
   // operator_multiplication
   template <typename T>
-  struct operator_multiplication_vv_func {
+  class operator_multiplication_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -244,7 +258,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_multiplication_vd_func {
+  class operator_multiplication_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v * 0.4847);
@@ -254,7 +269,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_multiplication_dv_func {
+  class operator_multiplication_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(0.3898 * v);
@@ -279,7 +295,8 @@ namespace nomad {
   
   // operator_subtraction_assignment
   template <typename T>
-  struct operator_subtraction_assignment_vv_func {
+  class operator_subtraction_assignment_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -289,7 +306,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_subtraction_assignment_vd_func {
+  class operator_subtraction_assignment_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v -= 0.4847);
@@ -313,7 +331,8 @@ namespace nomad {
   
   // operator_subtraction
   template <typename T>
-  struct operator_subtraction_vv_func {
+  class operator_subtraction_vv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       T v2 = x[1];
@@ -324,7 +343,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_subtraction_vd_func {
+  class operator_subtraction_vd_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(v - 0.4847);
@@ -334,7 +354,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_subtraction_dv_func {
+  class operator_subtraction_dv_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v = x[0];
       return exp(0.3898 - v);
@@ -359,7 +380,8 @@ namespace nomad {
 
   // operator_unary_decrement
   template <typename T>
-  struct operator_unary_decrement_prefix_func {
+  class operator_unary_decrement_prefix_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       return exp(++v1);
@@ -369,7 +391,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_unary_decrement_postfix_func {
+  class operator_unary_decrement_postfix_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       return exp(v1++);
@@ -387,7 +410,8 @@ namespace nomad {
   
   // operator_unary_increment
   template <typename T>
-  struct operator_unary_increment_prefix_func {
+  class operator_unary_increment_prefix_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       return exp(++v1);
@@ -397,7 +421,8 @@ namespace nomad {
   };
   
   template <typename T>
-  struct operator_unary_increment_postfix_func {
+  class operator_unary_increment_postfix_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       return exp(v1++);
@@ -415,7 +440,8 @@ namespace nomad {
   
   // operator_unary_minus
   template <typename T>
-  struct operator_unary_minus_func {
+  class operator_unary_minus_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       return exp(-v1);
@@ -432,7 +458,8 @@ namespace nomad {
 
   // operator_unary_plus
   template <typename T>
-  struct operator_unary_plus_func {
+  class operator_unary_plus_func: public base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       T v1 = x[0];
       return exp(+v1);

--- a/tests/validate_exceptions.hpp
+++ b/tests/validate_exceptions.hpp
@@ -7,7 +7,8 @@
 namespace nomad {
 
   template <typename T>
-  struct f_first_fail {
+  class f_first_fail: base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       first_fail<T>();
       return T();
@@ -15,7 +16,8 @@ namespace nomad {
   };
 
   template <typename T>
-  struct f_second_fail {
+  class f_second_fail: base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       second_fail<T>();
       return T();
@@ -23,7 +25,8 @@ namespace nomad {
   };
 
   template <typename T>
-  struct f_third_fail {
+  class f_third_fail: base_functor<T> {
+  public:
     T operator()(const Eigen::VectorXd& x) const {
       third_fail<T>();
       return T();


### PR DESCRIPTION
In the continuing effort to move all static checks to the compiler.
